### PR TITLE
onramp_pce_service.py modtest refactored to use PCE.tools.modules[jobs].

### DIFF
--- a/modules/AUC/tests/modtest.cfg
+++ b/modules/AUC/tests/modtest.cfg
@@ -13,7 +13,7 @@
 # 2) Complete this test file
 #
 # 3) Run the test file (must be from the onramp/pce directory)
-#  $$ ./bin/onramp_pce_service.py modtest ../modules/AUC/tests/modtest.cfg
+#  $$ bin/onramp_pce_service.py modtest ../modules/AUC/tests/modtest.cfg
 #
 
 # NOTE ON PATHS: All path settings may be either absolute, or relative to
@@ -22,8 +22,9 @@
 # Module root folder:
 module_path=../modules/AUC
 
-# Folder to deploy to (must not exist when test is run):
-deploy_path=~/tmp/onramp_pi_test
+# Folder to deploy to (module root will be a subfolder of this folder):
+deploy_path=~/tmp
+module_name=onramp_pi_test
 
 # Batch scheduler (current options: SLURM)
 batch_scheduler=SLURM

--- a/modules/mpi-ring/tests/modtest.cfg
+++ b/modules/mpi-ring/tests/modtest.cfg
@@ -13,7 +13,7 @@
 # 2) Complete this test file
 #
 # 3) Run the test file (must be from the onramp/pce directory)
-#  $$ ./onramp_pce_service.py modtest ../modules/mpi-ring/tests/modtest.cfg
+#  $$ bin/onramp_pce_service.py modtest ../modules/mpi-ring/tests/modtest.cfg
 #
 
 # NOTE ON PATHS: All path settings may be either absolute, or relative to
@@ -23,7 +23,8 @@
 module_path=../modules/mpi-ring
 
 # Folder to deploy to (must not exist when test is run):
-deploy_path=~/tmp/onramp_mpi-ring_test
+deploy_path=~/tmp
+module_name=onramp_mpi-ring_test
 
 # Batch scheduler (current options: SLURM)
 batch_scheduler=SLURM

--- a/modules/template/tests/modtest.cfg
+++ b/modules/template/tests/modtest.cfg
@@ -22,8 +22,9 @@
 # Module root folder:
 module_path=../modules/template
 
-# Folder to deploy to (must not exist when test is run):
-deploy_path=~/tmp/onramp_template_test
+# Folder to deploy to (module root will be a subfolder of this folder):
+deploy_path=~/tmp
+module_name=template
 
 # Batch scheduler (current options: SLURM)
 batch_scheduler=SLURM

--- a/modules/template/tests/modtest.cfg
+++ b/modules/template/tests/modtest.cfg
@@ -13,7 +13,7 @@
 # 2) Complete this test file
 #
 # 3) Run the test file (must be from the onramp/pce directory)
-#  $$ ./onramp_pce_service.py modtest ../modules/template/tests/modtest.cfg
+#  $$ bin/onramp_pce_service.py modtest ../modules/template/tests/modtest.cfg
 #
 
 # NOTE ON PATHS: All path settings may be either absolute, or relative to
@@ -25,9 +25,6 @@ module_path=../modules/template
 # Folder to deploy to (module root will be a subfolder of this folder):
 deploy_path=~/tmp
 module_name=template
-
-# Batch scheduler (current options: SLURM)
-batch_scheduler=SLURM
 
 # Number of tasks to configure in batch script
 num_tasks=4

--- a/pce/bin/onramp_pce_service.py
+++ b/pce/bin/onramp_pce_service.py
@@ -354,9 +354,8 @@ def _mod_test():
 
     # Postprocess.
     if args.verbose:
-        print 'Deploying module'
-    ret = job_postprocess(job_id, job_state_file=job_state_f[1])
-    if 0 != run_test(ret_val=ret, test=post_postprocess_test):
+        print 'Testing job postprocess'
+    if 0 != run_test(test=post_postprocess_test):
         return
 
     print 'No errors found.'

--- a/pce/bin/onramp_pce_service.py
+++ b/pce/bin/onramp_pce_service.py
@@ -194,6 +194,7 @@ def _mod_test():
     username = 'testuser'
     module_id = 1
     job_id = 1
+    ret_dir = os.getcwd()
 
     parser = argparse.ArgumentParser(prog='onramp_pce_service.py modtest',
                                      description=descrip)
@@ -217,7 +218,6 @@ def _mod_test():
                                '%s_%d' % (module_name, module_id))
     mod_state_f = mkstemp()
     job_state_f = mkstemp()
-    custom_runparams = abspath(expanduser(conf['custom_runparams']))
     post_deploy_test = ('post_deploy_test',
                         abspath(expanduser(conf['post_deploy_test'])))
     post_preprocess_test = ('post_preprocess_test',
@@ -228,12 +228,12 @@ def _mod_test():
                         abspath(expanduser(conf['post_status_test'])))
     post_postprocess_test = ('post_postprocess_test',
                    abspath(expanduser(conf['post_postprocess_test'])))
-    ret_dir = os.getcwd()
      
     def finish(conf, error=False):
         path = deploy_path
         results = job_output_file
         params = args
+
         os.close(mod_state_f[0])
         os.close(job_state_f[0])
         os.remove(mod_state_f[1])
@@ -311,6 +311,7 @@ def _mod_test():
     # Init job state.
     if args.verbose:
         print 'Initializing job state'
+    custom_runparams = ConfigObj(abspath(expanduser(conf['custom_runparams'])))
     ret = job_init_state(job_id, module_id, username, module_name,
                          custom_runparams, job_state_file=job_state_f[1],
                          mod_state_file=mod_state_f[1], run_dir=deploy_path)

--- a/pce/bin/onramp_pce_service.py
+++ b/pce/bin/onramp_pce_service.py
@@ -219,15 +219,20 @@ def _mod_test():
     mod_state_f = mkstemp()
     job_state_f = mkstemp()
     post_deploy_test = ('post_deploy_test',
-                        abspath(expanduser(conf['post_deploy_test'])))
+                        abspath(expanduser(os.path.join(
+                        deploy_path, conf['post_deploy_test']))))
     post_preprocess_test = ('post_preprocess_test',
-                        abspath(expanduser(conf['post_preprocess_test'])))
+                            abspath(expanduser(os.path.join(
+                            deploy_path, conf['post_preprocess_test']))))
     post_launch_test = ('post_launch_test',
-                        abspath(expanduser(conf['post_launch_test'])))
+                        abspath(expanduser(os.path.join(
+                        deploy_path, conf['post_launch_test']))))
     post_status_test = ('post_status_test',
-                        abspath(expanduser(conf['post_status_test'])))
+                        abspath(expanduser(os.path.join(
+                        deploy_path, conf['post_status_test']))))
     post_postprocess_test = ('post_postprocess_test',
-                   abspath(expanduser(conf['post_postprocess_test'])))
+                             abspath(expanduser(os.path.join(
+                             deploy_path, conf['post_postprocess_test']))))
      
     def finish(conf, error=False):
         path = deploy_path

--- a/pce/bin/onramp_pce_service.py
+++ b/pce/bin/onramp_pce_service.py
@@ -364,6 +364,7 @@ def _mod_test():
         return
 
     print 'No errors found.'
+    finish(conf, error=False)
 
 def _mod_install():
     """Install an OnRamp educational module from the given location.

--- a/pce/src/PCE/tools/jobs.py
+++ b/pce/src/PCE/tools/jobs.py
@@ -456,7 +456,7 @@ def _build_job(job_id, job_state_file=None):
                     return copy.deepcopy(job_state)
                 job_state['error'] = None
                 job_state['mod_status_output'] = None
-                p = Process(target=_job_postprocess, args=(job_id,))
+                p = Process(target=job_postprocess, args=(job_id, job_state_file))
                 p.start()
             elif job_status[1] == 'Running':
                 job_state['state'] = 'Running'

--- a/pce/src/PCE/tools/jobs.py
+++ b/pce/src/PCE/tools/jobs.py
@@ -60,7 +60,7 @@ class JobState(dict):
             id (int): Id of the job to get/create state for.
         """
         if jobs_state_file is None:
-			job_state_file = os.path.join(_job_state_dir, str(id))
+            job_state_file = os.path.join(_job_state_dir, str(id))
         self.job_id = id
 
         try:
@@ -140,13 +140,13 @@ def launch_job(job_id, mod_id, username, run_name, run_params):
             _logger.warn(msg)
             return (-1, msg)
 
-	job_init_state(job_id, mod_id, username, run_name, run_params)
-	job_preprocess(job_id)
-	job_run(job_id)
+    job_init_state(job_id, mod_id, username, run_name, run_params)
+    job_preprocess(job_id)
+    job_run(job_id)
 
 def job_init_state(job_id, mod_id, username, run_name, run_params,
-				   job_state_file=None, mod_state_file=None,
-				   run_dir=None):
+                   job_state_file=None, mod_state_file=None,
+                   run_dir=None):
 
     with JobState(job_id, job_state_file) as job_state:
         job_state['job_id'] = job_id
@@ -188,19 +188,19 @@ def job_init_state(job_id, mod_id, username, run_name, run_params,
 
     # Initialize dir structure.
     if run_dir is None:
-		user_dir = os.path.join(os.path.join(pce_root, 'users'), username)
-		user_mod_dir = os.path.join(user_dir, '%s_%d' % (mod_name, mod_id))
-		run_dir = os.path.join(user_mod_dir, run_name)
-		try:
-			os.mkdir(user_dir)
-		except OSError:
-			# Thrown if dir already exists.
-			pass
-		try:
-			os.mkdir(user_mod_dir)
-		except OSError:
-			# Thrown if dir already exists.
-			pass
+        user_dir = os.path.join(os.path.join(pce_root, 'users'), username)
+        user_mod_dir = os.path.join(user_dir, '%s_%d' % (mod_name, mod_id))
+        run_dir = os.path.join(user_mod_dir, run_name)
+        try:
+            os.mkdir(user_dir)
+        except OSError:
+            # Thrown if dir already exists.
+            pass
+        try:
+            os.mkdir(user_mod_dir)
+        except OSError:
+            # Thrown if dir already exists.
+            pass
 
     with JobState(job_id, job_state_file) as job_state:
         job_state['run_dir'] = run_dir
@@ -254,7 +254,7 @@ def job_preprocess(job_id, job_state_file=None):
         return (-1, msg)
     finally:
         module_log(run_dir, 'preprocess', result)
-		os.chdir(ret_dir)
+        os.chdir(ret_dir)
 
 def job_run(job_id, job_state_file=None):
     # Determine batch scheduler to user from config.
@@ -316,7 +316,7 @@ def job_postprocess(job_id, job_state_file=None):
         mod_id = job_state['mod_id']
         run_name = job_state['run_name']
         mod_name = job_state['mod_name']
-		run_dir = job_state['run_dir']
+        run_dir = job_state['run_dir']
     args = (username, mod_name, mod_id, run_name)
     ret_dir = os.getcwd()
 

--- a/pce/src/PCE/tools/modules.py
+++ b/pce/src/PCE/tools/modules.py
@@ -50,7 +50,7 @@ class ModState(dict):
             mod_state['key2'] = 'val2'
     """
 
-    def __init__(self, id):
+    def __init__(self, id, mod_state_file=None):
         """Return initialized ModState instance.
 
         Method works in get-or-create fashion, that is, if state exists for
@@ -59,7 +59,8 @@ class ModState(dict):
         Args:
             id (int): Id of the module to get/create state for.
         """
-        mod_state_file = os.path.join(_mod_state_dir, str(id))
+        if mod_state_file is None:
+            mod_state_file = os.path.join(_mod_state_dir, str(id))
         self.mod_id = id
 
         try:
@@ -142,7 +143,7 @@ def get_source_types():
     return source_handlers.keys()
 
 def install_module(source_type, source_path, install_parent_folder, mod_id,
-                   mod_name, verbose=False):
+                   mod_name, verbose=False, mod_state_dir=None):
     """Install OnRamp educational module into environment.
 
     Args:
@@ -167,7 +168,7 @@ def install_module(source_type, source_path, install_parent_folder, mod_id,
     _logger.debug('cwd: %s' % os.getcwd())
     _logger.debug('source_abs_path: %s' % source_abs_path)
 
-    with ModState(mod_id) as mod_state:
+    with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
         if 'state' in mod_state.keys():
             if mod_state['state'] == 'Checkout in progress':
                 return (-1, 'Module %d already undergoing install process'
@@ -191,7 +192,7 @@ def install_module(source_type, source_path, install_parent_folder, mod_id,
     result = source_handlers[source_type](source_abs_path, mod_dir)
 
     if result:
-        with ModState(mod_id) as mod_state:
+        with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
             mod_state['state'] = 'Checkout failed'
             mod_state['error'] = result
             if mod_state['_marked_for_del']:
@@ -206,7 +207,7 @@ def install_module(source_type, source_path, install_parent_folder, mod_id,
         # Dir already exists. All good.
         pass
 
-    with ModState(mod_id) as mod_state:
+    with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
         mod_state['state'] = 'Installed'
         mod_state['error'] = None
         mod_state['installed_path'] = mod_dir
@@ -216,7 +217,7 @@ def install_module(source_type, source_path, install_parent_folder, mod_id,
 
     return (0, 'Module %d installed' % mod_id)
 
-def deploy_module(mod_id, verbose=False):
+def deploy_module(mod_id, verbose=False, mod_state_dir=None):
     """Deploy an installed OnRamp educational module.
 
     Args:
@@ -233,7 +234,7 @@ def deploy_module(mod_id, verbose=False):
     not_installed_states = ['Available', 'Checkout in Progress',
                             'Checkout failed']
 
-    with ModState(mod_id) as mod_state:
+    with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
         if ('state' not in mod_state.keys()
             or mod_state['state'] in not_installed_states):
             return (-1, 'Module %d not installed' % mod_id)
@@ -260,7 +261,7 @@ def deploy_module(mod_id, verbose=False):
             code -= 256
         output = e.output
         if code != 1:
-            with ModState(mod_id) as mod_state:
+            with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
                 msg = ('Deploy exited with return status %d and output: %s'
                          % (code, output))
                 _logger.debug(msg)
@@ -270,7 +271,7 @@ def deploy_module(mod_id, verbose=False):
                     _delete_module(mod_state)
                     return (-3, 'Module %d deleted' % mod_id)
             return (-1, msg)
-        with ModState(mod_id) as mod_state:
+        with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
             msg = 'Admin required'
             _logger.debug(msg)
             mod_state['state'] = msg
@@ -283,7 +284,7 @@ def deploy_module(mod_id, verbose=False):
         output = str(e1)
         _logger.debug('OSError from bin/onramp_deploy.py')
         _logger.debug(e1)
-        with ModState(mod_id) as mod_state:
+        with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
             mod_state['state'] = 'Deploy failed'
             mod_state['error'] = str(e1)
         return (-1, str(e1))
@@ -292,7 +293,7 @@ def deploy_module(mod_id, verbose=False):
         module_log(mod_dir, 'deploy', output)
 
     _logger.debug("Updating state to 'Module ready'")
-    with ModState(mod_id) as mod_state:
+    with ModState(mod_id, mod_state_dir=mod_state_dir) as mod_state:
         mod_state['state'] = 'Module ready'
         mod_state['error'] = None
         if mod_state['_marked_for_del']:

--- a/pce/src/configspecs/modtest.cfgspec
+++ b/pce/src/configspecs/modtest.cfgspec
@@ -1,5 +1,6 @@
 module_path = string()
 deploy_path = string()
+module_name = string()
 batch_scheduler = option('SLURM')
 num_tasks = integer()
 results_check_sleep = float(default=5.0)

--- a/pce/src/testing/test_pce.py
+++ b/pce/src/testing/test_pce.py
@@ -7,9 +7,9 @@ This script is only intended to be run in a fresh install of the repository. It
 has side-effects that could corrupt module and user data if run in a production
 setting.
 
-Prior to running this script, ensure that onramp/pce/onramp_pce_setup.py has
-been called and that the server is running. Also Ensure ./test_pce_config.cfg
-contains the proper settings.
+Prior to running this script, ensure that onramp/pce/bin/onramp_pce_install.py
+has been called and that the server is running. Also Ensure
+./test_pce_config.cfg contains the proper settings.
 """
 import nose
 import sys


### PR DESCRIPTION
- PCE.tools.modules and PCE.tools.jobs refactored to facilitate usage by modtest
- modtest refactored to use updated PCE libs
- All unit tests pass on flux and brie
- modtest tested with success on flux and brie
- Existing modules' modtest.cfg files updated to new standard
- modtest now automatically supports additional cluster targets as they are implemented
