### PR TITLE
Job launch race condition fix.

### DIFF
--- a/server/src/webapp/onramppce.py
+++ b/server/src/webapp/onramppce.py
@@ -8,6 +8,7 @@ import os
 import requests
 import time
 
+
 class PCEAccess():
     """Client-side interface to OnRamp PCE server.
 
@@ -653,6 +654,15 @@ class PCEAccess():
 
         self._logger.debug("%s Checking on Job %d" % (prefix, job_id))
         job = self.get_jobs(job_id)
+
+        # This is a temp fix (though after analysis may prove to be THE fix). #
+        if 'job_id' not in job.keys():
+            job['job_id'] = job_id
+        if 'output' not in job.keys():
+            job['output'] = None
+        if 'state' not in job.keys():
+            job['state'] = 'Setting up launch'
+        #######################################################################
 
         self._logger.debug("%s job RAW %s" % (prefix, str(job)))
         self._save_job_output( job["job_id"], job["output"] )


### PR DESCRIPTION
Previous job and module state file locking mechanism placed a lock on the actual state file needed. Updated to use separate lock file as a lock. This allows the lock to be already held when state file is attempted to be opened in 'r+' and then opened in 'w' if it doesn't already exist, preventing a race condition. Additionally, added better handling of null job returned to onramppce._update_job_in_db() in the event the requested job has not finished launching.
